### PR TITLE
add the ability to set the essential flag for ecs tasks

### DIFF
--- a/container_transform/converter.py
+++ b/container_transform/converter.py
@@ -80,7 +80,7 @@ class Converter(object):
 
             input_name = options.get(self.input_type, {}).get('name')
 
-            if container.get(input_name) and \
+            if container.get(input_name) != None and \
                     hasattr(input_transformer, 'ingest_{}'.format(parameter)) and \
                     output_name and hasattr(output_transformer, 'emit_{}'.format(parameter)):
                 # call transform_{}
@@ -89,7 +89,7 @@ class Converter(object):
 
                 output[output_name] = emit_func(ingest_func(container.get(input_name)))
 
-            if not container.get(input_name) and output_required:
+            if not container.get(input_name) != None and output_required:
                 msg_template = 'Container {name} is missing required parameter "{output_name}".'
                 self.messages.add(
                     msg_template.format(

--- a/container_transform/ecs.py
+++ b/container_transform/ecs.py
@@ -101,9 +101,10 @@ class ECSTransformer(BaseTransformer):
 
     @staticmethod
     def validate(container):
-        container['essential'] = True
-
         container_name = container.get('name')
+
+        if container.get('essential') == None:
+            container['essential'] = True
 
         if not container_name:
             container_name = str(uuid.uuid4())

--- a/container_transform/schema.py
+++ b/container_transform/schema.py
@@ -301,7 +301,7 @@ ARG_MAP = OrderedDict({
             'required': False
         },
         TransformationTypes.COMPOSE.value: {
-            'name': None,
+            'name': 'essential',
             'required': False
         },
         TransformationTypes.SYSTEMD.value: {

--- a/container_transform/transformer.py
+++ b/container_transform/transformer.py
@@ -5,7 +5,8 @@ methods should produce and accept (respectively)"""
 SCHEMA = {
     'image': str,
     'name': str,
-    'cpu': int,  # out of 1024
+    'cpu': int,
+    'essential': bool,
     'memory': int,  # in bytes
     'links': list,  # This is universal across formats
     'logging': {
@@ -105,6 +106,12 @@ class BaseTransformer(object, metaclass=ABCMeta):
 
     def emit_name(self, name):
         return name
+
+    def ingest_essential(self, essential):
+        return essential
+
+    def emit_essential(self, essential):
+        return essential
 
     def ingest_image(self, image):
         return image


### PR DESCRIPTION
Adding the ability to set the `essential` attribute to something other than `True` for ECS task definitions.